### PR TITLE
remove GNU Makefile extensions

### DIFF
--- a/vignettes/Makefile
+++ b/vignettes/Makefile
@@ -5,10 +5,7 @@ all:
 
 .PHONY: data2 mapping2
 
-setvars:
-ifeq (${R_HOME},)
-R_HOME= $(shell R RHOME)
-endif
+R_HOME = `R RHOME`
 
 Pbase-data.html: Pbase-data.Rmd
 	## "$(R_HOME)/bin/Rscript" -e 'library("knitr"); library("rmarkdown"); knit("Pbase-data.Rmd"); render("Pbase-data.md")'
@@ -18,13 +15,13 @@ mapping.html: mapping.Rmd
 	## "$(R_HOME)/bin/Rscript" -e 'library("knitr"); library("rmarkdown"); knit("mapping.Rmd"); render("mapping.md")'
 	"$(R_HOME)/bin/Rscript" -e 'library("knitr"); knit2html("mapping.Rmd");'
 
-data2: 
+data2:
 	"$(R_HOME)/bin/Rscript" -e 'library("knitr"); library("rmarkdown"); knit("Pbase-data.Rmd"); render("Pbase-data.md")'
 
-mapping2: 
+mapping2:
 	"$(R_HOME)/bin/Rscript" -e 'library("knitr"); library("rmarkdown"); knit("mapping.Rmd"); render("mapping.md")'
 
-clean: 
+clean:
 	rm -f *~
 	rm -f .build.timestamp
 	rm -f .Rhistory


### PR DESCRIPTION
This PR fixes the following warning in the recent Rdevel (2015-02-08 r67773):
```
* checking for GNU extensions in Makefiles ... WARNING
Found the following file(s) containing GNU extensions:
  vignettes/Makefile
Portable Makefiles do not use GNU extensions such as +=, :=, $(shell),
$(wildcard), ifeq ... endif. See section ‘Writing portable packages’ in
the ‘Writing R Extensions’ manual.
```
@lgatto could you please double check if this is equivalent to your previous version.